### PR TITLE
[New] Add Click Listener and Automatically Scratch All Features

### DIFF
--- a/WScratchViewLibrary/src/com/winsontan520/IWScratchView.java
+++ b/WScratchViewLibrary/src/com/winsontan520/IWScratchView.java
@@ -95,4 +95,8 @@ public interface IWScratchView {
 	public float getScratchedRatio(int speed);
 
 	public void setOnScratchCallback(OnScratchCallback callback);
+
+    public void setScratchAll(boolean scratchAll);
+
+    public void setBackgroundClickable(boolean clickable);
 }

--- a/WScratchViewLibrary/src/com/winsontan520/WScratchView.java
+++ b/WScratchViewLibrary/src/com/winsontan520/WScratchView.java
@@ -71,6 +71,11 @@ public class WScratchView extends SurfaceView implements IWScratchView, SurfaceH
 	private Canvas mScratchedTestCanvas;
 	private OnScratchCallback mOnScratchCallback;
 
+    //Enable scratch all area if mClearCanvas is true
+    private boolean mClearCanvas = false;
+    //Enable click on WScratchView if mIsClickable is true
+    private boolean mIsClickable = false;
+
 	public WScratchView(Context ctx, AttributeSet attrs) {
 		super(ctx, attrs);
 		init(ctx, attrs);
@@ -138,6 +143,12 @@ public class WScratchView extends SurfaceView implements IWScratchView, SurfaceH
 	public void onDraw(Canvas canvas) {
 		super.onDraw(canvas);
 
+        //Clear all area if mClearCanvas is true
+        if(mClearCanvas){
+            canvas.drawColor(Color.TRANSPARENT, Mode.CLEAR);
+            return;
+        }
+
 		if (mScratchBitmap != null) {
 			if (mMatrix == null) {
 				float scaleWidth = (float) canvas.getWidth() / mScratchBitmap.getWidth();
@@ -192,6 +203,18 @@ public class WScratchView extends SurfaceView implements IWScratchView, SurfaceH
 				updateScratchedPercentage();
 				break;
 			case MotionEvent.ACTION_UP:
+                //Set call back if user's finger detach
+                mOnScratchCallback.onDetach(true);
+                //perform Click action if the motion is not move
+                //and the WScratchView is clickable
+                if(!mScratchStart && mIsClickable){
+                    post(new Runnable() {
+                        @Override
+                        public void run() {
+                            performClick();
+                        }
+                    });
+                }
 				mScratchStart = false;
 				break;
 			}
@@ -360,5 +383,19 @@ public class WScratchView extends SurfaceView implements IWScratchView, SurfaceH
 	
 	public static abstract class OnScratchCallback{
 		public abstract void onScratch(float percentage);
+        //Call back funtion to monitor the status of finger
+        public abstract void onDetach(boolean fingerDetach);
 	}
+
+    //Set the mClearCanvas
+    @Override
+    public void setScratchAll(boolean scratchAll){
+        mClearCanvas = scratchAll;
+    }
+
+    //Set the WScartchView clickable
+    @Override
+    public void setBackgroundClickable(boolean clickable){
+        mIsClickable = clickable;
+    }
 }


### PR DESCRIPTION
Hi Winson,

Thank you in advanced. I am currently using the WScratchView for my Android Application. I find some functions missing to my need:
1. I need the view to be scratched automatically, when the scratched are reach the threshold and the user's finger detached from the screen. This could be useful that the user does not need to scratch all the area manually if the background is clear exposed enough. So I add some codes in the onDraw() to "clear the view", and in the call back I add onDetach() to monitor the finger detach event;
2. When the view has been "scratched all", I need the background to be clickable to trigger another event. Since the onTouchEvent() happens before the onClick(), I add some code in "ACTION_UP" to performClick().

These two functions work properly in my side, so I would like to contribute to this library. Let me know if there is any problems. Thank you.

Regards,
Gilbert
